### PR TITLE
fix: Made fetch depth 0 to be able to use "git rev-list"

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Github actions only fetches the latest "history point" by default, and it didn't get any commit at all so "git rev-list --count HEAD" returned a value of 1 instead of 302. To fix that, I added a fetch depth of 0 (all history). 